### PR TITLE
Remove ROPC option

### DIFF
--- a/config/plw_env.sh
+++ b/config/plw_env.sh
@@ -11,10 +11,6 @@ export CONFIG_FILE=plw.yaml
 export BUCKET_NAME=plw-test-bucket # S3 bucket used for lambda storage
 export ENVIRONMENT=plw             # Environment name, used in some tags
 
-# OAuth2 flow in use. See the docs if you do not understand this. Valid values are
-# "client" and "ropc".
-export OAUTH2_FLOW=client
-
 # Number of reserved instances for performance. A good value is normally 1 or 2,
 # but you can set it to 0 if AWS quotas are preventing it working.
 export CONCURRENCY=0

--- a/config/seescape_env.sh
+++ b/config/seescape_env.sh
@@ -11,10 +11,6 @@ export CONFIG_FILE=plw.yaml
 export BUCKET_NAME=aws-sam-cli-managed-default-samclisourcebucket-3rhhfpjblgdf
 export ENVIRONMENT=seescape             # Environment name, used in some tags
 
-# OAuth2 flow in use. See the docs if you do not understand this. Valid values are
-# "client" and "ropc".
-export OAUTH2_FLOW=client
-
 # Number of reserved instances for performance. A good value is normally 1 or 2,
 # but you can set it to 0 if AWS quotas are preventing it working.
 export CONCURRENCY=1

--- a/docs/prereqs.md
+++ b/docs/prereqs.md
@@ -18,29 +18,13 @@ You must have done all the following before you start installation.
 
 The M365 requirements are to set up an M365 email account with a calendar to use, plus the capability for the application to log into it. This process is fiddly, but that's the trouble with security.
 
-*TODO: should retire ROPC flow, and be more prescriptive, including removing all mention of passwords.*
-
-Before you start working through the process, you need to decide what OAuth2 flow to use, because we are in that kind of world. There are two choices, either [ROPC (Resource Owner Password Credentials) flow](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth-ropc), or [client credentials flow](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow). The pros and cons of these methods are as follows.
-
-- Using ROPC is simpler. However, it means you must turn off MFA for the email account you use, and will pass the user account password around.
-
-- Using client credentials is a little more complex to set up, but avoids the above disadvantages.
-
-If this is all Greek to you, then you are very lucky to have been spared understanding OAuth2, and you should follow this flow.
-
-- If you cannot turn off MFA, use client credentials.
-
-- Otherwise, use ROPC.
-
-Good - we have a decision. Remember it.
-
 ### Process overview
 
 Setting this up requires three steps.
 
 1. Getting an [M365 tenant](#tenant).
 
-2. Creating an [email account](#account)
+2. Creating a [shared mailbox](#shared-mailbox)
 
 3. Setting up an [application](#application)
 
@@ -56,27 +40,19 @@ Store these off securely; you'll need all of them later.
 
 ### Tenant
 
-*TODO: probably worth just adding this to the assumptions, rather than saying that you might not already have one.*
+You must have an M365 business or enterprise tenant to use. Note that you can sign up for a [free M365 tenant as a non-profit](https://www.microsoft.com/en-gb/microsoft-365/nonprofit/), or failing that just create a [new tenant](https://www.microsoft.com/en-gb/microsoft-365/business/microsoft-365-plan-chooser).
 
-There are four options here.
+Once you have your tenant, you need to [find your organisation's tenant ID](https://learn.microsoft.com/en-us/sharepoint/find-your-office-365-tenant-id), and store it safely for future use.
 
-1. If you have Microsoft accounts managed by your organisation, you already have a tenant and should use that. You do need to [find your organisations tenant ID](https://learn.microsoft.com/en-us/sharepoint/find-your-office-365-tenant-id), and store it safely for future use, but can skip to [setting up an account](#account).
-
-2. Alternatively, you can sign up for your [free M365 tenant as a non-profit](https://www.microsoft.com/en-gb/microsoft-365/nonprofit/), and then proceed as above. This takes a few days and requires Microsoft to validate your charity. You should do this if you are thinking "wouldn't having some Microsoft managed email be useful".
-
-3. You can create an M365 tenant using the [the Microsoft developer program](https://learn.microsoft.com/en-us/entra/identity-platform/test-setup-environment?tabs=microsoft-365-developer-program). This only works if you have a paid for account of some kind already. I have not tested this.
-
-If none of these works, you can just bite the bullet and create a [new enterprise subscription](https://www.microsoft.com/en-gb/microsoft-365/business/microsoft-365-plan-chooser). This is free for 30 days, after which you have to pay £4.60 plus VAT per month (assuming you only have a single email address).
-
-### Account
+### Shared mailbox
 
 You'll need a mailbox in your organisation that can be accessed by staff managing the application and appointments. The easiest type of account to use is a [shared mailbox](https://learn.microsoft.com/en-us/microsoft-365/admin/email/about-shared-mailboxes). To create such an account, perform the following steps.
 
 - As an administrator, log into the [Microsoft admin centre](https://admin.microsoft.com/Adminportal/Home#/homepage).
 
-- Select the `Shared mailboxes` option, which is in the `Teams & Groups` section the left hand bar.
+- Select the `Shared mailboxes` option, which is in the `Teams & Groups` section on the left hand bar.
 
-- Click `Add a shared mailbox`, and assign it an email address and a name.
+- Click `Add a shared mailbox`, and assign it an email address and a name. A good email is something like `loneworker@example.com`.
 
 - After a little while (up to a minute or so), the new shared mailbox appears in the list of shared mailboxes. Click on it.
 
@@ -92,7 +68,7 @@ You now need to create and configure an *application*. This is the term that Mic
 
 - Create the application
 
-    - Go to the [Entra Admin Centre](https://entra.microsoft.com]
+    - Go to the [Entra Admin Centre](https://entra.microsoft.com)
 
     - Select `Applications` on the list on the left of the page, and within that select `App Registrations`.
 
@@ -106,7 +82,7 @@ You now need to create and configure an *application*. This is the term that Mic
 
         - Save off the `client ID` (shown as "Application (client) ID" in the overview)
 
-    - You have an app registration. *If you are using the client credentials model only*, create it some credentials.
+    - You have an app registration. Create it some credentials.
 
         - Go to `certificates and secrets`. Add a secret and save the value securely. You will never see this value again, so if you lose it, you will have to create a new secret.
 
@@ -118,11 +94,7 @@ You now need to create and configure an *application*. This is the term that Mic
 
     - Click the "Microsoft Graph" button in the list of services
 
-    - Where there is a button to pick permissions type:
-
-        - Pick `Application` for client credentials
-
-        - Pick `Delegated permissions` for ROPC.
+    - Where there is a button to pick permissions type, pick `Application`
 
     - Pick the relevant permission. The permissions you need to have checked are as follows.
 
@@ -138,29 +110,11 @@ You now need to create and configure an *application*. This is the term that Mic
 
     - Next to `Add a permission`, there is a button `Grant admin consent for <your tenant name>`. Click it.
 
-- *Only if you are using ROBC, i.e. a user password*, disable MFA for the user. Exactly how to do this varies according to enterprise.
-
-    - For most newly created test enterprises, this requires turning off "Security Defaults" if that is enforcing MFA, or modifying "Conditional Access Policies" if that is enforcing MFA.
-
-        - Go to the [Entra Admin Centre](https://entra.microsoft.com)
-
-        - Turn off security defaults
-
-            - Find `Microsoft Entra ID` (search for it in the search bar)
-
-            - Click `Properties`
-
-            - Click on `Security defaults`, and disable it. Ignore all the warnings about how terrible an idea this is.
-
-    - If you are using "Conditional Access Policies" then change those to exclude your user (which at least means that your org can enforce MFA for all other mailboxes).
-
-        - *No instructions here, since I have not actually done this.*
-
 #### Further client credentials steps
 
-Unfortunately, use of the client credentials model grants the application rights to every mailbox in the enterprise, which is not such a good idea. The solution is to use PowerShell to set up permissions to restrict it to a single mailbox (or more accurately to a group consisting of a single mailbox, the shared mailbox you created above). Instructions for this process are the following.
+Unfortunately, this grants the application rights to every mailbox in the enterprise, which is not such a good idea. The solution is to use PowerShell to set up permissions to restrict it to a single mailbox (or more accurately to a group consisting of a single mailbox, the shared mailbox you created above). Instructions for this process are the following.
 
-- Go to the [Entra Admin Centre](https://entra.microsoft.com]
+- Go to the [Entra Admin Centre](https://entra.microsoft.com)
 
 - Create a group.
 
@@ -168,11 +122,11 @@ Unfortunately, use of the client credentials model grants the application rights
 
     - Create a new group, of type `Mail-Enabled Security`, which we will assume is called `loneworker`.
 
-    - Give it an email. This email should be one that stops people accidentally inviting it to meetings - so do not give it something that can easily be confused with the lone worker shared mailbox mail.
+    - Give it an email. This email should be one that stops people accidentally inviting it to meetings - so do not give it something that can easily be confused with the lone worker shared mailbox mail. `nomailsg@example.com` is a good example.
 
     - Description I picked was "Users whose accounts the loneworker app can access"
 
-- Add the worker that you want to the group
+- Add the shared mailbox to the group
 
     - Find the group
 
@@ -214,5 +168,3 @@ Unfortunately, use of the client credentials model grants the application rights
 Config files - examples are `plw_env.sh`, and `plw.yaml`
 
 *TODO: Some documentation in the example file, needs beefing up*
-
-

--- a/scripts/initial.sh
+++ b/scripts/initial.sh
@@ -22,20 +22,10 @@ fi
 # Create the secrets; this is how it should be done so they are stored encrypted.
 # Note that this just puts in dummy values. There is a later step to manually set these dummy values correctly.
 echo "Creating secrets"
-if [ "${OAUTH2_FLOW}" == "ropc" ]; then
-    echo "  email password"
-    aws ssm put-parameter --name /${APP}/emailpass --description "Password for email account" \
-                        --value "DummySecretValue" --type "SecureString" \
-                        --tags ${TAGS}
-elif [ "${OAUTH2_FLOW}" == "client" ]; then
-    echo "  client secret"
-    aws ssm put-parameter --name /${APP}/clientsecret --description "Client secret for M365 application" \
-                        --value "DummySecretValue" --type "SecureString" \
-                        --tags ${TAGS}
-else
-    echo "Error: OAUTH2_FLOW must be either 'ropc' or 'client'"
-    exit 1
-fi
+echo "  client secret"
+aws ssm put-parameter --name /${APP}/clientsecret --description "Client secret for M365 application" \
+                      --value "DummySecretValue" --type "SecureString" \
+                      --tags ${TAGS}
 
 echo "  tenant ID"
 aws ssm put-parameter --name /${APP}/tenant --description "Tenant ID for M365 application" \

--- a/scripts/test_creds.py
+++ b/scripts/test_creds.py
@@ -5,6 +5,7 @@ import requests
 import os
 from urllib.parse import quote
 import json
+import jwt
 
 # Get some credentials
 def get_token(client_id, client_secret, tenant_id, scope):
@@ -108,11 +109,16 @@ if user is None:
 
 scope = 'https://graph.microsoft.com/.default' # Must use this for client credentials
 
-print("Here we go")
+print("Get token")
 token_response = get_token(client_id, client_secret, tenant_id, scope)
-print(token_response)
+print(json.dumps(token_response, indent=4))
 token = token_response["access_token"]
-print(f"token: {token}")
+
+# Decode without verifying the signature by setting options accordingly
+decoded = jwt.decode(token, options={"verify_signature": False})
+
+print("Decoded JWT:")
+print(json.dumps(decoded, indent=4))
 
 HEADERS = {
     'Authorization': 'Bearer ' + token,
@@ -122,7 +128,7 @@ HEADERS = {
 
 print("Get calendar")
 calendar_response = get_calendar(user)
-print(calendar_response)
+print(json.dumps(calendar_response, indent=4))
 
 print("Get events")
 calendar_events = get_calendar_events(user)


### PR DESCRIPTION
We are going to just use client credentials going forward, as it is so much easier to manage - so remove the docs and code that mentioned the ROPC option.