### PR TITLE
Workaround astonishing bug in AWS cloud formation dashboard handling

### DIFF
--- a/config/seescape_env.sh
+++ b/config/seescape_env.sh
@@ -3,7 +3,7 @@
 export AWS_PROFILE=seescape
 
 # This must be a valid yaml file in the same directory.
-export CONFIG_FILE=plw.yaml
+export CONFIG_FILE=seescape.yaml
 
 # Various other parameters that must be passed around into both scripts and cloudformation.
 # None of these may include spaces or special characters.

--- a/scripts/lambdas.sh
+++ b/scripts/lambdas.sh
@@ -11,7 +11,10 @@ source scripts/utils.sh
 STACK_NAME="${APP}-lambdas"
 create_or_update_stack ${STACK_NAME} "lambdas.yaml"  "--capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_NAMED_IAM"
 
+export DATE=$(date -u "+%Y%m%dT%H:%M:%SZ")
+echo ${DATE}
+
 STACK_NAME="${APP}-dashboard"
-create_or_update_stack ${STACK_NAME} "dashboard.yaml"
+create_or_update_stack ${STACK_NAME} "dashboard.yaml" "" "ParameterKey=date,ParameterValue=${DATE}"
 
 echo "SUCCESS"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -12,10 +12,12 @@ create_or_update_stack() {
     # - Stack name
     # - YAML file (in the templates directory)
     # - extra args (such as capabilities) - optional
+    # - extra parameters (in key=x,value=y format - optional)
     # Sets the value to be performed - either "create-stack" or "update-stack" - in the variable OPERATION
     local STACK_NAME=$1
     local YAML_FILE=$2
     local EXTRA_ARGS=${3:-""}
+    local EXTRA_PARAMS=${4:-""}
     echo "Creating or updating stack ${STACK_NAME}"
     if ! aws cloudformation describe-stacks --stack-name ${STACK_NAME} > /dev/null 2>&1
     then
@@ -29,7 +31,7 @@ create_or_update_stack() {
     aws cloudformation ${OPERATION} --stack-name ${STACK_NAME} \
                                     --template-body file://templates/${YAML_FILE} \
                                     ${EXTRA_ARGS} \
-                                    --parameters ${PARAMETERS} \
+                                    --parameters ${PARAMETERS} ${EXTRA_PARAMS}\
                                     --tags ${TAGS}
 
     aws cloudformation describe-stacks --stack-name ${STACK_NAME}

--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -11,6 +11,9 @@ Parameters:
   app:
     Type: String
     Description: App name used for tagging and naming
+  date:
+    Type: String
+    Description: Date now
 Resources:
   ConnectFunctionErrorAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -131,8 +134,7 @@ Resources:
       DashboardName:
         Fn::Sub: "${app}"
       DashboardBody:
-        Fn::Sub:
-          - |
+        Fn::Sub: |
             {
                 "widgets": [
                     {
@@ -244,13 +246,13 @@ Resources:
                         "properties": {
                             "title": "Issues in past 12 hours",
                             "alarms": [
-                                "${MissedCheckinsAlarm}",
-                                "${EmergencyCallsAlarm}",
-                                "${MissedCheckoutsAlarm}",
-                                "${ConnectFunctionErrorAlarm}",
-                                "${ConnectFunctionThrottleAlarm}",
-                                "${CheckFunctionErrorAlarm}",
-                                "${CheckFunctionThrottleAlarm}"
+                                "arn:${AWS::Partition}:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${MissedCheckinsAlarm}",
+                                "arn:${AWS::Partition}:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${MissedCheckoutsAlarm}",
+                                "arn:${AWS::Partition}:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${EmergencyCallsAlarm}",
+                                "arn:${AWS::Partition}:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${ConnectFunctionErrorAlarm}",
+                                "arn:${AWS::Partition}:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${ConnectFunctionThrottleAlarm}",
+                                "arn:${AWS::Partition}:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${CheckFunctionErrorAlarm}",
+                                "arn:${AWS::Partition}:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${CheckFunctionThrottleAlarm}"
                             ]
                         }
                     },
@@ -275,16 +277,16 @@ Resources:
                             "setPeriodToTimeRange": true,
                             "trend": false
                         }
+                    },
+                    {
+                        "type": "text",
+                        "x": 12,
+                        "y": 9,
+                        "width": 6,
+                        "height": 5,
+                        "properties": {
+                            "markdown": "This dashboard shows the following.\n\n- Total number of missed calls and emergencies in the time period covered.\n- Whether there were any alarms (serious errors) in the past 12 hours.\n- Graphs of rates of operations and metrics as counters per 900 second period over the period covered.\n\n\nThe dashboard was last updated ${date}.\n"
+                        }
                     }
                 ]
-            }
-          - {
-              app: !Ref app,
-              MissedCheckinsAlarm: !Join [ "", [ "arn:aws:cloudwatch:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":alarm:", { "Ref": "MissedCheckinsAlarm" } ] ],
-              EmergencyCallsAlarm: !Join [ "", [ "arn:aws:cloudwatch:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":alarm:", { "Ref": "EmergencyCallsAlarm" } ] ],
-              MissedCheckoutsAlarm: !Join [ "", [ "arn:aws:cloudwatch:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":alarm:", { "Ref": "MissedCheckoutsAlarm" } ] ],
-              ConnectFunctionErrorAlarm: !Join [ "", [ "arn:aws:cloudwatch:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":alarm:", { "Ref": "ConnectFunctionErrorAlarm" } ] ],
-              ConnectFunctionThrottleAlarm: !Join [ "", [ "arn:aws:cloudwatch:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":alarm:", { "Ref": "ConnectFunctionThrottleAlarm" } ] ],
-              CheckFunctionErrorAlarm: !Join [ "", [ "arn:aws:cloudwatch:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":alarm:", { "Ref": "CheckFunctionErrorAlarm" } ] ],
-              CheckFunctionThrottleAlarm: !Join [ "", [ "arn:aws:cloudwatch:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":alarm:", { "Ref": "CheckFunctionThrottleAlarm" } ] ]
             }


### PR DESCRIPTION
AWS cloud formation templates are idempotent unless they include dashboards, in which case they fail if you update a dashboard to the same value it already has with a meaningless error.

Fixed by adding a date parameter to the dashboard so it will change every time it is uploaded.